### PR TITLE
fix: count insert+delete chars as edit volume (#89)

### DIFF
--- a/exportWhoDidWhat.js
+++ b/exportWhoDidWhat.js
@@ -5,88 +5,24 @@ const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 const authorManager = require('ep_etherpad-lite/node/db/AuthorManager');
 
-exports.whoDidWhat = async (padId, revNum, cb) => {
-  const exists = await padManager.doesPadExists(padId);
-  if (!exists) {
-    console.error('Pad does not exist');
-    cb('pad does not exist', null);
+// Returns the volume of a changeset — i.e. how many characters were inserted
+// plus how many were deleted. The previous implementation used the difference
+// between oldLen and newLen, which incorrectly reported zero when a user
+// REPLACED text (e.g. fixed a typo) and so excluded their contribution from
+// the report whenever delete length matched insert length. See issue #89.
+exports.changesetVolume = (changeset) => {
+  const unpacked = Changeset.unpack(changeset);
+  const iter = Changeset.opIterator(unpacked.ops);
+  let volume = 0;
+  while (iter.hasNext()) {
+    const op = iter.next();
+    if (op.opcode === '+' || op.opcode === '-') volume += op.chars;
   }
-
-  // get the pad
-  const pad = await padManager.getPad(padId);
-  const head = pad.getHeadRevisionNumber();
-
-  // create an array with all revisions
-  const revisions = [];
-
-  for (let i = 0; i <= head; i++) {
-    revisions.push(i);
-  }
-
-  const authors = await pad.getAllAuthors();
-  const authorsObj = {};
-  const items = {};
-  const threshold = 1; // CAKE TODO
-
-  for (const author of Object.keys(authors)) {
-    let color = await authorManager.getAuthorColorId(authors[author]);
-    const authorName = await authorManager.getAuthorName(authors[author]);
-    authorsObj[authors[author]] = {};
-    authorsObj[authors[author]].name = authorName;
-
-    if (typeof color === 'string' && color.indexOf('#') !== -1) {
-      authorsObj[authors[author]].color = color;
-    } else {
-      // color needs to come from index
-      const palette = authorManager.getColorPalette();
-      color = palette[color];
-      authorsObj[authors[author]].color = color;
-    }
-  }
-
-  // run trough all revisions
-  async.forEachSeries(revisions, async (revNum, callback) => {
-    const revision = await pad.getRevision(revNum);
-
-    if (authorsObj[revision.meta.author]) {
-      let authorName = authorsObj[revision.meta.author].name;
-      if (!authorName) authorName = 'Anonymous';
-      const opType = typeOfOp(revision.changeset);
-      const unpacked = Changeset.unpack(revision.changeset);
-      const changeLength = Math.abs(unpacked.oldLen - unpacked.newLen);
-      const per = Math.round((100 / unpacked.oldLen) * changeLength);
-      const humanTime = new Date(revision.meta.timestamp).toLocaleTimeString();
-      const humanDate = new Date(revision.meta.timestamp).toDateString();
-
-      // By default we ignore any percentage that is lower than 1%
-      if (per > threshold) {
-        // console.log(keyword, logString);
-        items[revNum] = {
-          timestamp: revision.meta.timestamp,
-          time: humanTime,
-          date: humanDate,
-          authorName,
-          opType,
-          changeLength,
-          percent: per,
-        };
-      }
-    }
-
-    // setImmediate required else it will crash on large pads
-    // See https://caolan.github.io/async/v3/ Common Pitfalls
-    /*
-    async.setImmediate(() => {
-      callback();
-    });
-    */
-  }, () => {
-    cb(null, items);
-  });
+  return volume;
 };
 
-// returns "-", "+" or "=" depending on the type of edit
-const typeOfOp = (changeset) => {
+// Returns "-", "+" or "=" depending on the dominant op type.
+exports.typeOfOp = (changeset) => {
   const unpacked = Changeset.unpack(changeset);
   const iter = Changeset.opIterator(unpacked.ops);
   let code;
@@ -100,12 +36,79 @@ const typeOfOp = (changeset) => {
         code = '-';
         break;
       case '+':
-      {
         code = '+';
         break;
-      }
+    }
+  }
+  return code;
+};
+
+exports.whoDidWhat = async (padId, revNum, cb) => {
+  const exists = await padManager.doesPadExists(padId);
+  if (!exists) {
+    console.error('Pad does not exist');
+    return cb('pad does not exist', null);
+  }
+
+  const pad = await padManager.getPad(padId);
+  const head = pad.getHeadRevisionNumber();
+
+  const revisions = [];
+  for (let i = 0; i <= head; i++) revisions.push(i);
+
+  const authors = await pad.getAllAuthors();
+  const authorsObj = {};
+  const items = {};
+  // Edits smaller than this fraction of the document are excluded from the
+  // report. Compared with `>=` (was previously `>`) so that small but real
+  // edits at the threshold aren't dropped.
+  const thresholdPercent = 1;
+
+  for (const author of Object.keys(authors)) {
+    let color = await authorManager.getAuthorColorId(authors[author]);
+    const authorName = await authorManager.getAuthorName(authors[author]);
+    authorsObj[authors[author]] = {};
+    authorsObj[authors[author]].name = authorName;
+
+    if (typeof color === 'string' && color.indexOf('#') !== -1) {
+      authorsObj[authors[author]].color = color;
+    } else {
+      const palette = authorManager.getColorPalette();
+      color = palette[color];
+      authorsObj[authors[author]].color = color;
     }
   }
 
-  return code;
+  async.forEachSeries(revisions, async (revNum) => {
+    const revision = await pad.getRevision(revNum);
+
+    if (!authorsObj[revision.meta.author]) return;
+    let authorName = authorsObj[revision.meta.author].name;
+    if (!authorName) authorName = 'Anonymous';
+
+    const opType = exports.typeOfOp(revision.changeset);
+    const unpacked = Changeset.unpack(revision.changeset);
+    const changeLength = exports.changesetVolume(revision.changeset);
+
+    // The first edit grows the pad from oldLen=0; use the post-edit length
+    // for the percentage so we don't divide by zero.
+    const denom = unpacked.oldLen || unpacked.newLen;
+    const per = denom ? Math.round((100 / denom) * changeLength) : 0;
+
+    if (per >= thresholdPercent) {
+      const humanTime = new Date(revision.meta.timestamp).toLocaleTimeString();
+      const humanDate = new Date(revision.meta.timestamp).toDateString();
+      items[revNum] = {
+        timestamp: revision.meta.timestamp,
+        time: humanTime,
+        date: humanDate,
+        authorName,
+        opType,
+        changeLength,
+        percent: per,
+      };
+    }
+  }, () => {
+    cb(null, items);
+  });
 };

--- a/static/tests/backend/specs/changeset_volume.js
+++ b/static/tests/backend/specs/changeset_volume.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('assert').strict;
+const Changeset = require('ep_etherpad-lite/static/js/Changeset');
+const exporter = require('../../../../exportWhoDidWhat');
+
+// Build a changeset directly so we don't need a running pad/server.
+const buildChangeset = (oldText, newText) => Changeset.makeSplice(
+    oldText, 0, oldText.length, newText);
+
+describe(__filename, function () {
+  describe('changesetVolume()', function () {
+    it('counts a pure insert', function () {
+      const cs = buildChangeset('', 'hello world');
+      assert.equal(exporter.changesetVolume(cs), 11);
+    });
+
+    it('counts a pure delete', function () {
+      const cs = buildChangeset('hello world', '');
+      assert.equal(exporter.changesetVolume(cs), 11);
+    });
+
+    // Regression for #89: same length REPLACE used to report volume 0
+    // because the old impl was `Math.abs(oldLen - newLen)`, which lost
+    // every contributor whose edits were corrections rather than appends.
+    it('counts a same-length replace (regression for #89)', function () {
+      const cs = buildChangeset('hello world', 'world hello');
+      // 11 chars deleted + 11 inserted (the diff is a full swap).
+      // Old impl returned 0; we just need this to be > 0.
+      assert(exporter.changesetVolume(cs) > 0,
+          'same-length replace must report non-zero volume');
+    });
+
+    it('counts a partial replace shorter than original', function () {
+      const cs = buildChangeset('hello world', 'hi');
+      // 11 deleted, 2 inserted = 13. Old impl reported abs(11-2)=9.
+      assert.equal(exporter.changesetVolume(cs), 13);
+    });
+  });
+
+  describe('typeOfOp()', function () {
+    it('returns + for an insert', function () {
+      assert.equal(exporter.typeOfOp(buildChangeset('', 'hello')), '+');
+    });
+    it('returns - for a delete', function () {
+      assert.equal(exporter.typeOfOp(buildChangeset('hello', '')), '-');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The previous implementation reported edit volume as \`Math.abs(oldLen - newLen)\` — the change in document LENGTH. That measure is zero whenever a user replaced text with the same number of characters (e.g. a typo correction, a wording swap), so any contributor whose edits were *corrections* rather than *appends* was filtered out of the report by the \`>1%\` threshold. This is the user-visible symptom in #89: \"two or more users contributed more than 1%, but the version history only includes one user's contributions\".

## Fix
Walk the changeset ops directly and sum the character counts of \`+\` and \`-\` ops. Also:

- Move the per-revision percentage's denominator off \`oldLen\`, which is 0 for the very first edit and made the per-edit math \`NaN\`/\`Infinity\`.
- Switch the threshold check to \`>=\` so edits at exactly 1% aren't dropped.
- Inline early-return when the revision has no known author (previous callback was never invoked).

## Test
Added \`static/tests/backend/specs/changeset_volume.js\` covering pure inserts, pure deletes, **same-length replaces (the #89 regression case)**, and partial replaces. All 6 tests pass locally.

Fixes #89

Generated with [Claude Code](https://claude.com/claude-code)