### PR TITLE
a11y: drop redundant hardcoded aria-label

### DIFF
--- a/templates/button.ejs
+++ b/templates/button.ejs
@@ -1,7 +1,7 @@
 <ul><!-- note this is a temp fix -->
   <li data-type="button" data-key="who_did_what" onClick="toggleWhoDidWhatReport();">
-    <a class="grouped-left ep_who_did_what" data-l10n-id="ep_who_did_what" title="Who did what?" aria-label="who did what">
-      <button class="buttonicon buttonicon-who_did_what ep_who_did_what" data-l10n-id="ep_who_did_what_" title="Who did what?" aria-label="who_did_what">🔍</button>
+    <a class="grouped-left ep_who_did_what" data-l10n-id="ep_who_did_what" title="Who did what?">
+      <button class="buttonicon buttonicon-who_did_what ep_who_did_what" data-l10n-id="ep_who_did_what_" title="Who did what?">🔍</button>
     </a>
   </li>
 </ul>


### PR DESCRIPTION
## Summary

Removes hardcoded `aria-label="…"` attributes from elements that already declare `data-l10n-id`. With `aria-label` set in the template, etherpad's html10n skips the auto-population path (`html10n.ts:665-678`) and leaves screen readers with the English label even when the user's UI language is something else.

After this PR, html10n populates `aria-label` from the localized translation on every `pad.applyLanguage()` call, marked with `data-l10n-aria-label="true"` so subsequent passes refresh it.

Also drops the `data-l10n-attr="aria-label"` attribute where present — that's a convention from a different localization library (e.g. fluent-dom), and etherpad's html10n does not read it. The auto-population in lines 665-678 is the etherpad mechanism.

Part of the fleet-wide plugin a11y/i18n sweep (Phase 3 of the modernization campaign; pilot: ether/ep_align#182).