### PR TITLE
a11y: flatten interactive nesting (restore localized aria-label)

### DIFF
--- a/templates/button.ejs
+++ b/templates/button.ejs
@@ -1,7 +1,8 @@
-<ul><!-- note this is a temp fix -->
+<ul>
   <li data-type="button" data-key="who_did_what" onClick="toggleWhoDidWhatReport();">
-    <a class="grouped-left ep_who_did_what" data-l10n-id="ep_who_did_what" title="Who did what?">
-      <button class="buttonicon buttonicon-who_did_what ep_who_did_what" data-l10n-id="ep_who_did_what_" title="Who did what?">🔍</button>
-    </a>
+    <a class="grouped-left ep_who_did_what buttonicon buttonicon-who_did_what"
+       role="button" tabindex="0"
+       data-l10n-id="ep_who_did_what"
+       title="Who did what?">🔍</a>
   </li>
 </ul>


### PR DESCRIPTION
## Summary

Flattens nested toolbar markup to a single `<a role="button" tabindex="0">` carrying the icon classes. With no element children (or with a recognized attribute suffix in `data-l10n-id`), etherpad's html10n auto-populates `aria-label` from the localized string per `html10n.ts:665-678`.

**Why this PR exists:** the earlier Phase 3a sweep removed hardcoded `aria-label="…"` on toolbar buttons that have element children (`<span>`/`<button>`) and a `data-l10n-id` without a recognized attribute suffix (`.title`/`.alt`/`.value`/`.placeholder`). For those elements, html10n skips its auto-population path, so they ended up with no accessible name. Flattening the structure makes the auto-population fire.