### PR TITLE
refactor: adopt template helper for 2 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {template} = require('ep_plugin_helpers');
+
 /**
  * Copyright 2020 John McLear <john@mclear.co.uk>
  *
@@ -24,15 +26,11 @@ exports.eejsBlock_timesliderScripts = (fn, args, cb) => {
   cb();
 };
 
-exports.eejsBlock_timesliderEditbarRight = (fn, args, cb) => {
-  args.content += eejs.require('ep_who_did_what/templates/button.ejs', {}, module);
-  cb();
-};
+exports.eejsBlock_timesliderEditbarRight =
+    template('ep_who_did_what/templates/button.ejs');
 
-exports.eejsBlock_timesliderBody = (fn, args, cb) => {
-  args.content += eejs.require('ep_who_did_what/templates/modal.ejs', {}, module);
-  cb();
-};
+exports.eejsBlock_timesliderBody =
+    template('ep_who_did_what/templates/modal.ejs');
 
 exports.clientVars = (hook, context, callback) => {
   if (!settings.ep_what_have_i_missed) settings.ep_what_have_i_missed = {};

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/ether/ep_who_did_what.git"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 2 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.