### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/exportWhoDidWhat.js
+++ b/exportWhoDidWhat.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const async = require('ep_etherpad-lite/node_modules/async');
+const async = require('async');
 const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 const authorManager = require('ep_etherpad-lite/node/db/AuthorManager');

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const {template} = require('ep_plugin_helpers');
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 const settings = require('ep_etherpad-lite/node/utils/Settings');
 
 exports.eejsBlock_timesliderScripts = (fn, args, cb) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ep_who_did_what",
-  "version": "11.0.30",
+  "version": "11.0.31",
   "description": "Who made what changes to a pad?  A historical report available in the timeslider",
   "author": "John McLear <john@mclear.co.uk>",
   "contributors": [],
@@ -25,6 +25,7 @@
     "url": "https://github.com/ether/ep_who_did_what.git"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.6.2"
+    "ep_plugin_helpers": "^0.6.2",
+    "async": "^3.2.6"
   }
 }


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Changes:**
1. Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")` (in `index.js`)
2. Replace `require("ep_etherpad-lite/node_modules/async")` with `require("async")` (in `exportWhoDidWhat.js`)

Both changes are **backward-compatible** with the current CJS etherpad release.